### PR TITLE
Fall back to first option of NOVOPlasty if not circular

### DIFF
--- a/docker/wrapper.sh
+++ b/docker/wrapper.sh
@@ -121,7 +121,13 @@ EOF
 
     NOVOPlasty.pl -c config.txt
 
-    cp Circularized_assembly_1_NOVOPlasty.fasta ../output.fa
+    if [ -e Circularized_assembly_1_NOVOPlasty.fasta ]
+    then
+        cp Circularized_assembly_1_NOVOPlasty.fasta ../output.fa
+    else
+        cp Option_1_NOVOPlasty.fasta ../output.fa
+    fi
+    
 fi
 
 if [ -n "$CHLOROPLASTASSEMBLYPROTOCOL" ]


### PR DESCRIPTION
If `NOVOPlasty` is unable to find a complete circular chloroplast the file `Circularized_assembly_1_NOVOPlasty.fasta` is not created at all. According to the [documentation](https://github.com/ndierckx/NOVOPlasty#4-output-files) different options are returned with names like `Option_nr_projectname.txt`. So we can just copy the first option as final result. This behavior is not perfect as `NOVOPlasty` does not promote this as the best option or an assumed final chloroplast. Still for our benchmarking we can consider this as the best guess rather than assuming a complete failure on the dataset.

Fix #12