### PR TITLE
Quotation marks are taken literal in NOVOPlasty

### DIFF
--- a/docker/wrapper.sh
+++ b/docker/wrapper.sh
@@ -103,7 +103,7 @@ Type                  = chloro
 Genome Range          = 100000-250000
 K-mer                 = 39
 Max memory            =
-Extended log          = 0
+Extended log          = 1
 Save assembled reads  = no
 Seed Input            = $REFERENCE
 Reference sequence    =
@@ -119,8 +119,8 @@ Insert size           = $INSERTSIZE
 Platform              = illumina
 Single/Paired         = PE
 Combined reads        =
-Forward reads         = "${FW_READ}"
-Reverse reads         = "${REV_READ}"
+Forward reads         = ${FW_READ}
+Reverse reads         = ${REV_READ}
 
 Optional:
 -----------------------


### PR DESCRIPTION
NOVOPlasty tries to open file "forward.fq" instead of forward.fq. Returns:  `error file "forward.fq"  not found`
PR fixes this bug.
Furthermore we changed the extended log option in NOVOPlasty's log file to 1