### PR TITLE
Quotation error in CAP

### DIFF
--- a/docker/wrapper.sh
+++ b/docker/wrapper.sh
@@ -159,8 +159,8 @@ then
     cd input
     # generate an interleaved file from our input files
     perl -e '
-       open(my $fw,"../../"${FW_READ}"")  || die("$!\n");
-       open(my $rev,"../../"${REV_READ}"") || die("$!\n");
+       open(my $fw,"../../'${FW_READ}'")  || die("$!\n");
+       open(my $rev,"../../'${REV_READ}'") || die("$!\n");
 
        my $readnumber = 0;
 

--- a/docker/wrapper.sh
+++ b/docker/wrapper.sh
@@ -159,8 +159,8 @@ then
     cd input
     # generate an interleaved file from our input files
     perl -e '
-       open(my $fw,"../../'${FW_READ}'")  || die("$!\n");
-       open(my $rev,"../../'${REV_READ}'") || die("$!\n");
+       open(my $fw,"../../'"${FW_READ}"'")  || die("$!\n");
+       open(my $rev,"../../'"${REV_READ}"'") || die("$!\n");
 
        my $readnumber = 0;
 


### PR DESCRIPTION
Bad usage of double quotes instead of single quotes in perl -e  causes script to fail with following error message.
PR fixes this bug 

```
perl: warning: Falling back to the standard locale ("C").
Scalar found where operator expected at -e line 2, near ""../../"${FW_READ}"
        (Missing operator before ${FW_READ}?)
String found where operator expected at -e line 2, near "${FW_READ}"""
        (Missing operator before ""?)
Scalar found where operator expected at -e line 3, near ""../../"${REV_READ}"
        (Missing operator before ${REV_READ}?)
String found where operator expected at -e line 3, near "${REV_READ}"""
        (Missing operator before ""?)
syntax error at -e line 2, near ""../../"${FW_READ}"
syntax error at -e line 3, near ""../../"${REV_READ}"
```