### PR TITLE
Added third output file option to novoplasty

### DIFF
--- a/docker/wrapper.sh
+++ b/docker/wrapper.sh
@@ -150,9 +150,12 @@ EOF
 
     if [ -e Circularized_assembly_1_NOVOPlasty.fasta ]
     then
-        cp Circularized_assembly_1_NOVOPlasty.fasta ../output.fa
+       	cp Circularized_assembly_1_NOVOPlasty.fasta ../output.fa
+    elif [ -e Option_1_NOVOPlasty.fasta ]
+    then
+       	cp Option_1_NOVOPlasty.fasta ../output.fa
     else
-        cp Option_1_NOVOPlasty.fasta ../output.fa
+        cp Contigs_1_NOVOPlasty.fasta ../output.fa
     fi
 
 fi

--- a/docker/wrapper.sh
+++ b/docker/wrapper.sh
@@ -154,8 +154,11 @@ EOF
     elif [ -e Option_1_NOVOPlasty.fasta ]
     then
        	cp Option_1_NOVOPlasty.fasta ../output.fa
-    else
+    elif [ -e Contigs_1_NOVOPlasty.fasta ]
+    then
         cp Contigs_1_NOVOPlasty.fasta ../output.fa
+    else
+        echo -n "" >../output.fa
     fi
 
 fi


### PR DESCRIPTION
Novoplasty has more than two options for output file names. It failed with  the error message: `cp: cannot stat 'Option_1_NOVOPlasty.fasta': No such file or directory` 
The output file generated however was `Contigs_1_NOVOPlasty.fasta` in some cases
By adding the `elif` condition it should be copied in `output.fa` if the other aforementioned files are not available