### PR TITLE
Update link to zenodo location for test sets

### DIFF
--- a/03_representative_datasets.md
+++ b/03_representative_datasets.md
@@ -6,7 +6,7 @@ We use both simulated and real data.
 
 ## Simulated Data
 The final simulation data is available from zenodo: 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2644937.svg)](https://doi.org/10.5281/zenodo.2644937)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2622875.svg)](https://doi.org/10.5281/zenodo.2622875)
 
 If you want to reproduce the simulation yourself please follow these instructions:
 


### PR DESCRIPTION
Using the top-DOI for linking to the test sets at Zenodo

fixes #43